### PR TITLE
Allow installation behind an HTTP proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "color-blind": "^0.1.0",
     "css-color-names": "0.0.1",
-    "hex-color-regex": "git@github.com:btholt/hex-color-regex.git",
+    "hex-color-regex": "https://github.com/btholt/hex-color-regex.git",
     "hsl-regex": "^1.0.0",
     "hsla-regex": "^1.0.0",
     "onecolor": "^2.5.0",


### PR DESCRIPTION
Similar to these issues on other projects https://github.com/npm/npm/issues/5257 https://github.com/atom/atom/issues/2309. 

All this is, is that some networks prevent the use of the `git://` protocol so the following git config is needed.

```
[url "https://"]
    insteadOf = git:// 
```

This PR makes a small change to `package.json` which was overriding the above.

Thanks for this great project.

Jamie [@fold_left](https://twitter.com/fold_left)