### PR TITLE
Add hexa-color-regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "color-blind": "^0.1.0",
     "css-color-names": "0.0.1",
     "hex-color-regex": "https://github.com/btholt/hex-color-regex.git",
+    "hexa-color-regex": "1.0.0",
     "hsl-regex": "^1.0.0",
     "hsla-regex": "^1.0.0",
     "onecolor": "^2.5.0",


### PR DESCRIPTION
Missing hexa-color-regex dependency in [color-transformer.js#L8](https://github.com/btholt/postcss-colorblind/blob/ab0b11ddc1344e6e3f2fa94d73ba2d6b84bb2b70/src/color-transformer.js#L8)
